### PR TITLE
fix: remove endOfLine from prettier

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -14,6 +14,7 @@
     "react": { "version": "detect"}
   },
   "rules": {
+   "prettier/prettier": "error",
     // suppress errors for missing 'import React' in files
    "react/react-in-jsx-scope": "off",
    "react/prop-types": "off",

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -14,7 +14,12 @@
     "react": { "version": "detect"}
   },
   "rules": {
-   "prettier/prettier": "error",
+   "prettier/prettier": [
+     "error",
+     {
+       "endOfLine": "auto"
+     }
+   ],
     // suppress errors for missing 'import React' in files
    "react/react-in-jsx-scope": "off",
    "react/prop-types": "off",

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -3,6 +3,5 @@
   "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 120,
-  "tabWidth": 2,
-  "endOfLine": "lf"
+  "tabWidth": 2
 }


### PR DESCRIPTION
### What this PR does (required):
- I removed from .prettierrc file the endOfLine param, and added to eslint the prettier errors that was not in there. Also in the other PR I added .editorconfig file that is the best place to have a configuration to endOfLine.

### Screenshots / Videos (required):
- Post at least one screenshot to show the feature in action

### Any information needed to test this feature (required):
- Post what steps to take to be able to test this feature (eg. "sign up as a new user and upload a profile picture from the navbar")

### Any issues with the current functionality (optional):
- List any problems where you were not able to complete all tasks on ticket
- List any problems this PR may cause for the project or other active PRs
- Post a screenshot/video of the problem, along with detailed console outputs where applicable
